### PR TITLE
Requires only the necessary core_ext from active_support.

### DIFF
--- a/lib/airborne/base.rb
+++ b/lib/airborne/base.rb
@@ -1,5 +1,5 @@
 require 'json'
-require 'active_support/core_ext/hash'
+require 'active_support/hash_with_indifferent_access'
 
 module Airborne
 	include RequestExpectations


### PR DESCRIPTION
base.rb seem to only require the hash extension but was requiring the
whole active_support/core_ext. That injected
active_support/core_ext/object/json.rb in the call chain.
When you have an object composed of other objects where the parent
doesn't define :to_json it would completely ignore :to_json defined
in the children, using active_support's instead.
