### PR TITLE
Fix problem with undefined status code method for Rack::MockResponse

### DIFF
--- a/lib/airborne/rack_test_requester.rb
+++ b/lib/airborne/rack_test_requester.rb
@@ -5,6 +5,9 @@ module Airborne
     def make_request(method, url, options = {})
       browser = Rack::Test::Session.new(Rack::MockSession.new(Airborne.configuration.rack_app))
       browser.send(method, url, options[:body] || {}, options[:headers] || {})
+      Rack::MockResponse.class_eval do
+        alias_method :code, :status
+      end
       browser.last_response
     end
   end


### PR DESCRIPTION
Hi.

This patch fixes problem for `expect_status` Airborne DSL method. 

When used with Rack application, `expect_status` compares status code passed to that method with value returned by `response.code` method. That method does not exist in `Rack::MockRequest`. 

https://github.com/brooklynDev/airborne/blob/master/lib/airborne/request_expectations.rb#L34

There is `status` method in `Rack::MockRequest` instead.

This commit adds method `code` that is alias for `status` in `Rack::MockResponse`

Kind regards,
 Grzegorz
