### PR TITLE
Reformat use of stabby lambda's to support jRuby

### DIFF
--- a/lib/airborne/request_expectations.rb
+++ b/lib/airborne/request_expectations.rb
@@ -211,7 +211,7 @@ module Airborne
     # @param expected_size [Integer]
     # @return [Proc]
     def convert_expectation_for_json_sizes(expected_size)
-      -> (data) { expect(data.size).to eq(expected_size) }
+      ->(data) { expect(data.size).to eq(expected_size) }
     end
 
     def is_property?(expectations)

--- a/spec/airborne/expectations/expect_json_lambda_spec.rb
+++ b/spec/airborne/expectations/expect_json_lambda_spec.rb
@@ -5,7 +5,7 @@ describe 'expect_json lambda' do
   it 'should invoke proc passed in' do
     mock_get('simple_get')
     get '/simple_get'
-    expect_json({name: -> (name){expect(name.length).to eq(4)}})
+    expect_json({name: ->(name){expect(name.length).to eq(4)}})
   end
-  
+
 end

--- a/spec/airborne/expectations/expect_json_path_spec.rb
+++ b/spec/airborne/expectations/expect_json_path_spec.rb
@@ -60,13 +60,13 @@ describe 'expect_json with path' do
   it 'should check for one match that matches all with lambda' do
     mock_get('array_with_nested')
     get '/array_with_nested'
-    expect_json('cars.?.owners.*', {name: -> (name){expect(name).to eq("Bart Simpson")}})
+    expect_json('cars.?.owners.*', {name: ->(name){expect(name).to eq("Bart Simpson")}})
   end
 
   it 'should ensure one match that matches all with lambda' do
     mock_get('array_with_nested')
     get '/array_with_nested'
-    expect{expect_json('cars.?.owners.*', {name: -> (name){expect(name).to eq("Bart Simpsons")}})}.to raise_error
+    expect{expect_json('cars.?.owners.*', {name: ->(name){expect(name).to eq("Bart Simpsons")}})}.to raise_error
   end
 
   it 'should ensure one match that matches all' do

--- a/spec/airborne/expectations/expect_json_types_lambda_spec.rb
+++ b/spec/airborne/expectations/expect_json_types_lambda_spec.rb
@@ -5,7 +5,7 @@ describe 'expect_json_types lambda' do
 	it 'should invoke proc passed in' do
     mock_get('simple_get')
     get '/simple_get'
-    expect_json_types({name: -> (name){expect(name.length).to eq(4)}})
+    expect_json_types({name: ->(name){expect(name.length).to eq(4)}})
   end
 
 end


### PR DESCRIPTION
Replacing `-> (data) {...}` with `->(data) {...}` (note the removal of the space) avoids syntax errors with jRuby.
