### PR TITLE
Remove specific versioning that result in gem conflicts

### DIFF
--- a/airborne.gemspec
+++ b/airborne.gemspec
@@ -8,9 +8,9 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.files = `git ls-files`.split("\n")
   s.license     = 'MIT'
-  s.add_runtime_dependency 'rspec', '~> 3.1', '>= 3.1.0'
+  s.add_runtime_dependency 'rspec'
   s.add_runtime_dependency 'rest-client', '~> 1.7', '>= 1.7.2'
   s.add_runtime_dependency 'rack-test', '~> 0.6', '>= 0.6.2'
-  s.add_runtime_dependency 'activesupport', '>= 4.0.1', '>= 4.0.1'
+  s.add_runtime_dependency 'activesupport'
   s.add_development_dependency 'webmock', '~> 0'
 end


### PR DESCRIPTION
Getting some dependency conflicts with the specific versions of rspec and activesupport in the gemspec (Bundler could not find compatible versions for gem "activesupport", etc.).
