### PR TITLE
Fixed JSON parse bug

### DIFF
--- a/lib/airborne/rest_client_requester.rb
+++ b/lib/airborne/rest_client_requester.rb
@@ -9,7 +9,7 @@ module Airborne
       res = if method == :post || method == :patch || method == :put
         begin
           options[:body] = JSON.parse(options[:body])
-        resuce JSON::ParseError
+        rescue JSON::ParserError
           options[:body].nil? ? "" : options[:body]
         end
         begin


### PR DESCRIPTION
It is now possible to run a spec like

```
  it 'should xyz' do
    post "/test", 'hallo', :content_type => 'text/plain'

    expect_status(200)
    expect(body).to eq('hallo')
  end
```

Because of JSON parsing the string "hallo" got two quotes which caused the spec to fail.
