### PR TITLE
Enable base header support when testing Rack applications

### DIFF
--- a/lib/airborne/rack_test_requester.rb
+++ b/lib/airborne/rack_test_requester.rb
@@ -3,8 +3,11 @@ require 'rack/test'
 module Airborne
   module RackTestRequester
     def make_request(method, url, options = {})
+      headers = options[:headers] || {}
+      base_headers = Airborne.configuration.headers || {}
+      headers = base_headers.merge(headers)
       browser = Rack::Test::Session.new(Rack::MockSession.new(Airborne.configuration.rack_app))
-      browser.send(method, url, options[:body] || {}, options[:headers] || {})
+      browser.send(method, url, options[:body] || {}, headers)
       Rack::MockResponse.class_eval do
         alias_method :code, :status
       end


### PR DESCRIPTION
Enabled base header support for rack application tests, quite similar to when using the rest-client. Documentation must not be changed since there was no hint that it did not work ;-)