### PR TITLE
Tests fail under RSpec 3.2 due to Airborne#initialize needing to accept arguments

### DIFF
--- a/spec/stub_helper.rb
+++ b/spec/stub_helper.rb
@@ -2,7 +2,7 @@ require 'webmock/rspec'
 
 module StubHelper
 
-  def initialize
+  def initialize(*args)
     @base_url = 'http://www.example.com/'
   end
 


### PR DESCRIPTION
Since the gem wasn't using the constructor arguments before, I've just altered StubHelper to accept splat arguments and then ignored them. This turns the test suite green, however long-term people might want to change this behaviour to something more contextual.