### PR TITLE
Feature: Allowing symbolized statuses to be passed to #expect_status matcher

### DIFF
--- a/lib/airborne/request_expectations.rb
+++ b/lib/airborne/request_expectations.rb
@@ -1,5 +1,6 @@
 require 'rspec'
 require 'date'
+require 'rack/utils'
 
 module Airborne
   class ExpectationError < StandardError; end
@@ -32,7 +33,7 @@ module Airborne
     end
 
     def expect_status(code)
-      expect(response.code).to eq(code)
+      expect(response.code).to eq(resolve_status(code, response.code))
     end
 
     def expect_header(key, content)
@@ -229,5 +230,20 @@ module Airborne
       [String, Regexp, Float, Fixnum, Bignum, TrueClass, FalseClass, NilClass].include?(expectations.class)
     end
 
+    # Resolve a supplied status to the appropriate class for the returned
+    # status being tested. This helps reduce brittleness due to '200' != 200
+    # when for the purposes of testing a response it is the same thing.
+    #
+    # @param candidate
+    # @param authority
+    # @return [String]
+    def resolve_status(candidate, authority)
+      candidate = Rack::Utils::SYMBOL_TO_STATUS_CODE[candidate] if candidate.kind_of?(Symbol)
+      case authority
+      when String then candidate.to_s
+      when Fixnum then candidate.to_i
+      else candidate
+      end
+    end
   end
 end

--- a/spec/airborne/expectations/expect_status_spec.rb
+++ b/spec/airborne/expectations/expect_status_spec.rb
@@ -12,4 +12,12 @@ describe 'expect_status' do
     get '/simple_get'
     expect{expect_status(123)}.to raise_error
   end
+
+  it 'should translate symbol codes to whatever is appropriate for the request' do
+    mock_get('simple_get')
+    get '/simple_get'
+    expect_status(:ok)
+    expect_status(200)
+    expect_status('200')
+  end
 end


### PR DESCRIPTION
Being able to use symbol status codes allows much more legible test suites, especially when more esoteric codes are being used. An example lies below:

```ruby
describe UsersController do
  describe 'POST create' do
    it 'should return 409 if email already taken' do
      post users_path, user_params_with_duplicate_email
      expect_status "409"
    end

    # Alternatively, you could do:

    it 'should return :conflict if email already taken' do
      post users_path, user_params_with_duplicate_email
      expect_status :conflict
    end
  end
end
```

This prevents having to access [HTTP Status Dogs](http://httpstatusdogs.com/) to remember what 409 means. 

I've used Rack::Utils inbuilt hash mapping to perform the conversion between symbolized status and the string value, and as part of the conversion process then casting the result to a string also allows use of Fixnum statuses as well if anybody wanted to.

Hope this is of interest to you, thanks for a really useful project.