### PR TITLE
Fix headers not passing during rack-test request

### DIFF
--- a/lib/airborne/rack_test_requester.rb
+++ b/lib/airborne/rack_test_requester.rb
@@ -7,6 +7,7 @@ module Airborne
       base_headers = Airborne.configuration.headers || {}
       headers = base_headers.merge(headers)
       browser = Rack::Test::Session.new(Rack::MockSession.new(Airborne.configuration.rack_app))
+      headers.each { |name, value| browser.header(name, value) }
       browser.send(method, url, options[:body] || {}, headers)
       Rack::MockResponse.class_eval do
         alias_method :code, :status


### PR DESCRIPTION
When making a rack-test request (Rack app is mounted during airborne
config), the parameters were not passed into the request. For example:

```
get '/endpoint', { 'Content-Type' => 'text/plain' }
```

Would result in the /endpoint being hit without the above Content-Type
header. This commit resolves the issue by using the `header` method on
rack-test's `Session` class.

http://www.rubydoc.info/gems/rack-test/0.6.3/Rack/Test/Session#header-instance_method