### PR TITLE
Fix expect_json in case a property is a hash and keys differ

### DIFF
--- a/lib/airborne/request_expectations.rb
+++ b/lib/airborne/request_expectations.rb
@@ -187,7 +187,7 @@ module Airborne
       expectations.each do |prop_name, expected_value|
         actual_value = ensure_hash_contains_prop(prop_name, hash) {hash[prop_name]}
         expected_class = expected_value.class
-        next expect_json_impl(expected_value, actual_value) if expected_class == Hash
+        next expect(actual_value).to match(expected_value) if expected_class == Hash
         next expected_value.call(actual_value) if expected_class == Proc
         next expect(actual_value.to_s).to match(expected_value) if expected_class == Regexp
         expect(actual_value).to eq(expected_value)

--- a/spec/airborne/expectations/expect_json_spec.rb
+++ b/spec/airborne/expectations/expect_json_spec.rb
@@ -11,13 +11,19 @@ describe 'expect_json' do
   it 'should fail when incorrect json is tested' do
     mock_get('simple_get')
     get '/simple_get'
-    expect{expect_json({bad: "data"})}.to raise_error   
+    expect{expect_json({bad: "data"})}.to raise_error
   end
-  
+
   it 'should allow full object graph' do
     mock_get('simple_path_get')
     get '/simple_path_get'
     expect_json({name: "Alex", address: {street: "Area 51", city: "Roswell", state: "NM"}})
+  end
+
+  it 'should ensure keys in hashes do match' do
+    mock_get('hash_property')
+    get '/hash_property'
+    expect{expect_json({person: {name: "Alex", something: nil}})}.to raise_error
   end
 
 end

--- a/spec/test_responses/hash_property.json
+++ b/spec/test_responses/hash_property.json
@@ -1,0 +1,3 @@
+{
+	"person": { "name": "Alex" }
+}


### PR DESCRIPTION
When a top level property is a hash and that hash contains keys with nil values, we want expect_json to error if actual and expected differ... Imo the two responses:

{"foo": {"bar": null}}

and

{"foo": {}}

are technically different and we should be able to express that with the expect_json matcher.
