### PR TITLE
Fix cherry-picking Active Support core extension

### DIFF
--- a/lib/airborne/base.rb
+++ b/lib/airborne/base.rb
@@ -1,5 +1,6 @@
 require 'json'
-require 'active_support/hash_with_indifferent_access'
+require 'active_support'
+require 'active_support/core_ext/hash/indifferent_access'
 
 module Airborne
   class InvalidJsonError < StandardError; end


### PR DESCRIPTION
As suggested in the Rails guide, we first need to require 'active_support',
(supposed to have near-zero footprint) - without it other gems may
incorrectly assume it can access methods on the ActiveSupport module, for
instance .on_load and this will result in a NoMethodError.

The awesome_print gem is one such example.

Here's a little example how to quickly verify the error:

```ruby
# require "active_support"
require "active_support/core_ext/hash/indifferent_access"
require "awesome_print"

puts "I'm ok!"
```

This is due to:
https://github.com/michaeldv/awesome_print/blob/d8aeb66b4b03dfb2cc1aec4e3187ced2f826d11f/lib/awesome_print.rb#L28-L32