### PR TITLE
Added ability to specify custom rack browser...

### DIFF
--- a/lib/airborne.rb
+++ b/lib/airborne.rb
@@ -10,6 +10,7 @@ RSpec.configure do |config|
   config.add_setting :base_url
   config.add_setting :headers
   config.add_setting :rack_app
+  config.add_setting :rack_browser
   config.add_setting :requester_type
   config.add_setting :requester_module
 end

--- a/lib/airborne/base.rb
+++ b/lib/airborne/base.rb
@@ -18,7 +18,7 @@ module Airborne
   def self.included(base)
     if !Airborne.configuration.requester_module.nil?
       base.send(:include, Airborne.configuration.requester_module)
-    elsif !Airborne.configuration.rack_app.nil?
+    elsif !Airborne.configuration.rack_app.nil? || !Airborne.configuration.rack_browser.nil?
       base.send(:include, RackTestRequester)
     else
       base.send(:include, RestClientRequester)

--- a/lib/airborne/rack_test_requester.rb
+++ b/lib/airborne/rack_test_requester.rb
@@ -6,7 +6,8 @@ module Airborne
       headers = options[:headers] || {}
       base_headers = Airborne.configuration.headers || {}
       headers = base_headers.merge(headers)
-      browser = Rack::Test::Session.new(Rack::MockSession.new(Airborne.configuration.rack_app))
+      browser = Airborne.configuration.rack_browser
+      browser ||= Rack::Test::Session.new(Rack::MockSession.new(Airborne.configuration.rack_app))
       headers.each { |name, value| browser.header(name, value) }
       browser.send(method, url, options[:body] || {}, headers)
       Rack::MockResponse.class_eval do

--- a/spec/airborne/rack/rack_sinatra_browser_spec.rb
+++ b/spec/airborne/rack/rack_sinatra_browser_spec.rb
@@ -1,0 +1,23 @@
+require 'json'
+require 'sinatra'
+
+class SampleApp < Sinatra::Application
+  before do
+    content_type 'application/json'
+  end
+
+  get '/' do
+    { foo: 'bar' }.to_json
+  end
+end
+
+Airborne.configure do |config|
+  config.rack_browser = Rack::Test::Session.new(Rack::MockSession.new(SampleApp))
+end
+
+describe 'rack app via browser' do
+  it 'should allow requests against a sinatra app' do
+    get '/'
+    expect_json_types(foo: :string)
+  end
+end


### PR DESCRIPTION
This is to be able to make multiple requests within the same session. At the moment, there's no possibility to do that easily because browser (thus session) is being recreated for each call. This pull request solves the problem by adding config param `rack_browser`, that can be used instead (and takes precedence) of `rack_app`.

Best,
Kris