### PR TITLE
Allow expectations on consecutive requests to work

### DIFF
--- a/lib/airborne/base.rb
+++ b/lib/airborne/base.rb
@@ -58,7 +58,7 @@ module Airborne
   end
 
   def json_body
-    set_response(@response) if @json_body.nil? && !@response.nil?
+    set_response(@response) unless @response.nil?
     fail InvalidJsonError, 'Api request returned invalid json' unless @json_body
     @json_body
   end

--- a/spec/airborne/rack/rack_sinatra_spec.rb
+++ b/spec/airborne/rack/rack_sinatra_spec.rb
@@ -31,4 +31,13 @@ describe 'rack app' do
     @response = Response.new({ foo: 'bar' }.to_json)
     expect(json_body).to eq(foo: 'bar')
   end
+
+  it 'Should work with consecutive requests' do
+    Response = Struct.new(:body, :headers)
+    @response = Response.new({ foo: 'bar' }.to_json)
+    expect(json_body).to eq(foo: 'bar')
+
+    @response = Response.new({ foo: 'boo' }.to_json)
+    expect(json_body).to eq(foo: 'boo')
+  end
 end


### PR DESCRIPTION
Hope you can help me out with this as I'm not completely familiar with the code and most likely doing something I shouldn't :sweat_smile: 

The problem I ran into was when using Airborne with Rails/Rspec. Making expectations on multiple
consecutive requests within a spec would fail, as the JSON would be cached after the first request. Ie, something like this would result in failure:

```ruby
it 'Should work with consecutive requests' do
  get '/posts' # returns { post: "post" }
  expect(json_body).to eq(post: 'post')

  get '/articles' # returns { article: "article" }
  expect(json_body).to eq(article: 'article') # Fails, json_body returns cached post JSON
end
```

Removing the condition on the cached `@json_body` variables "fixes" it, but I suppose that was in there for performance reasons. Not sure if there's a better way to fix it?