### PR TITLE
Add DELETE functionality when options are passed in

### DIFF
--- a/lib/airborne/base.rb
+++ b/lib/airborne/base.rb
@@ -45,8 +45,8 @@ module Airborne
     @response = make_request(:put, url, body: put_body, headers: headers)
   end
 
-  def delete(url, headers = nil)
-    @response = make_request(:delete, url, headers: headers)
+  def delete(url, delete_body = nil, headers = nil)
+    @response = make_request(:delete, url, body: delete_body, headers: headers)
   end
 
   def head(url, headers = nil)

--- a/spec/airborne/delete_spec.rb
+++ b/spec/airborne/delete_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'delete' do
   it 'should allow testing on delete requests' do
     mock_delete 'simple_delete'
-    delete '/simple_delete'
+    delete '/simple_delete', {}
     expect_status 200
   end
 end

--- a/spec/stub_helper.rb
+++ b/spec/stub_helper.rb
@@ -24,8 +24,9 @@ module StubHelper
       .to_return(headers: options[:response_headers] || {}, body: get_json_response_file(url), status: status)
   end
 
-  def mock_delete(url)
-    stub_request(:delete, @base_url + url)
+  def mock_delete(url, options = {}, status = 200)
+    stub_request(:delete, @base_url + url).with(body: options[:request_body] || {})
+    .to_return(headers: options[:response_headers] || {}, body: get_json_response_file(url), status: status)
   end
 
   def mock_head(url, response_headers = {}, status = 200)

--- a/spec/test_responses/simple_delete.json
+++ b/spec/test_responses/simple_delete.json
@@ -1,0 +1,4 @@
+{
+	"status": "ok",
+	"someNumber": 100
+}


### PR DESCRIPTION
I have a delete endpoint that needs to get passed in a json_body and keep receiving `wrong number of arguments (0 for 1..2)` I think this change in the gem might help? 

The parameters needed for the DELETE: 
```
{
  "contact_ids": [
    "string"
  ]
}
```

First PR to an open source project so please be gentle! :)