### PR TITLE
Adding specific errors to raise_error  to prevent RSpec warnings

### DIFF
--- a/spec/airborne/base_spec.rb
+++ b/spec/airborne/base_spec.rb
@@ -17,7 +17,7 @@ describe 'base spec' do
     mock_get('invalid_json')
     get '/invalid_json'
     expect(body).to eq('1234')
-    expect { json_body }.to raise_error
+    expect { json_body }.to raise_error(Airborne::InvalidJsonError)
   end
 
   it 'when request is made headers should be hash with indifferent access' do

--- a/spec/airborne/expectations/expect_header_contains_spec.rb
+++ b/spec/airborne/expectations/expect_header_contains_spec.rb
@@ -10,12 +10,12 @@ describe 'expect header contains' do
   it 'should ensure header is present' do
     mock_get('simple_get', 'Content-Type' => 'application/json')
     get '/simple_get'
-    expect { expect_header_contains(:foo, 'bar') }.to raise_error
+    expect { expect_header_contains(:foo, 'bar') }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 
   it 'should ensure partial header is present' do
     mock_get('simple_get', 'Content-Type' => 'application/json')
     get '/simple_get'
-    expect { expect_header_contains(:content_type, 'bar') }.to raise_error
+    expect { expect_header_contains(:content_type, 'bar') }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 end

--- a/spec/airborne/expectations/expect_header_spec.rb
+++ b/spec/airborne/expectations/expect_header_spec.rb
@@ -10,12 +10,12 @@ describe 'expect header' do
   it 'should find exact match for header content' do
     mock_get('simple_get', 'Content-Type' => 'json')
     get '/simple_get'
-    expect { expect_header(:content_type, 'application/json') }.to raise_error
+    expect { expect_header(:content_type, 'application/json') }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 
   it 'should ensure correct headers are present' do
     mock_get('simple_get', 'Content-Type' => 'application/json')
     get '/simple_get'
-    expect { expect_header(:foo, 'bar') }.to raise_error
+    expect { expect_header(:foo, 'bar') }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 end

--- a/spec/airborne/expectations/expect_json_keys_path_spec.rb
+++ b/spec/airborne/expectations/expect_json_keys_path_spec.rb
@@ -10,6 +10,6 @@ describe 'expect_json_keys with path' do
   it 'should fail when keys are missing with path' do
     mock_get('simple_nested_path')
     get '/simple_nested_path', {}
-    expect { expect_json_keys('address', [:bad]) }.to raise_error
+    expect { expect_json_keys('address', [:bad]) }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 end

--- a/spec/airborne/expectations/expect_json_keys_spec.rb
+++ b/spec/airborne/expectations/expect_json_keys_spec.rb
@@ -4,7 +4,7 @@ describe 'expect_json_keys' do
   it 'should fail when json keys are missing' do
     mock_get('simple_json')
     get '/simple_json', {}
-    expect { expect_json_keys([:foo, :bar, :baz, :bax]) }.to raise_error
+    expect { expect_json_keys([:foo, :bar, :baz, :bax]) }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 
   it 'should ensure correct json keys' do

--- a/spec/airborne/expectations/expect_json_path_spec.rb
+++ b/spec/airborne/expectations/expect_json_path_spec.rb
@@ -35,7 +35,7 @@ describe 'expect_json with path' do
   it 'should ensure at least one match' do
     mock_get('array_with_index')
     get '/array_with_index'
-    expect { expect_json('cars.?.make', 'Teslas') }.to raise_error
+    expect { expect_json('cars.?.make', 'Teslas') }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 
   it 'should check for at least one match' do
@@ -47,7 +47,9 @@ describe 'expect_json with path' do
   it 'should ensure at least one match' do
     mock_get('array_with_nested')
     get '/array_with_nested'
-    expect { expect_json('cars.?.owners.?', name: 'Bart Simpsons') }.to raise_error
+    expect {
+      expect_json('cars.?.owners.?', name: 'Bart Simpsons')
+    }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 
   it 'should check for one match that matches all ' do
@@ -65,13 +67,17 @@ describe 'expect_json with path' do
   it 'should ensure one match that matches all with lambda' do
     mock_get('array_with_nested')
     get '/array_with_nested'
-    expect { expect_json('cars.?.owners.*', name: ->(name) { expect(name).to eq('Bart Simpsons') }) }.to raise_error
+    expect {
+      expect_json('cars.?.owners.*', name: ->(name) { expect(name).to eq('Bart Simpsons') })
+    }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 
   it 'should ensure one match that matches all' do
     mock_get('array_with_nested')
     get '/array_with_nested'
-    expect { expect_json('cars.?.owners.*', name: 'Bart Simpsons') }.to raise_error
+    expect {
+      expect_json('cars.?.owners.*', name: 'Bart Simpsons')
+    }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 
   it 'should allow indexing' do

--- a/spec/airborne/expectations/expect_json_regex_spec.rb
+++ b/spec/airborne/expectations/expect_json_regex_spec.rb
@@ -10,7 +10,7 @@ describe 'expect_json regex' do
   it 'should raise an error if regex does not match' do
     mock_get('simple_get')
     get '/simple_get'
-    expect { expect_json(name: regex('^B')) }.to raise_error
+    expect { expect_json(name: regex('^B')) }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 
   it 'should allow regex(Regexp) to be tested against a path' do

--- a/spec/airborne/expectations/expect_json_spec.rb
+++ b/spec/airborne/expectations/expect_json_spec.rb
@@ -10,7 +10,7 @@ describe 'expect_json' do
   it 'should fail when incorrect json is tested' do
     mock_get('simple_get')
     get '/simple_get'
-    expect { expect_json(bad: 'data') }.to raise_error
+    expect { expect_json(bad: 'data') }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 
   it 'should allow full object graph' do
@@ -22,6 +22,6 @@ describe 'expect_json' do
   it 'should ensure keys in hashes do match' do
     mock_get('hash_property')
     get '/hash_property'
-    expect { expect_json(person: { name: 'Alex', something: nil }) }.to raise_error
+    expect { expect_json(person: { name: 'Alex', something: nil }) }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 end

--- a/spec/airborne/expectations/expect_json_types_path_spec.rb
+++ b/spec/airborne/expectations/expect_json_types_path_spec.rb
@@ -34,7 +34,7 @@ describe 'expect_json_types wih path' do
   it 'should ensure all elements of array are valid' do
     mock_get('array_with_index')
     get '/array_with_index'
-    expect { expect_json_types('cars.*', make: :string, model: :int) }.to raise_error
+    expect { expect_json_types('cars.*', make: :string, model: :int) }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 
   it 'should deep symbolize array responses' do
@@ -52,7 +52,7 @@ describe 'expect_json_types wih path' do
   it 'should ensure all nested arrays contain correct data' do
     mock_get('array_with_nested_bad_data')
     get '/array_with_nested_bad_data'
-    expect { expect_json_types('cars.*.owners.*', name: :string) }.to raise_error
+    expect { expect_json_types('cars.*.owners.*', name: :string) }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 
   it 'should raise ExpectationError when expectation expects an object instead of type' do

--- a/spec/airborne/expectations/expect_json_types_spec.rb
+++ b/spec/airborne/expectations/expect_json_types_spec.rb
@@ -10,7 +10,7 @@ describe 'expect_json_types' do
   it 'should fail when incorrect json types tested' do
     mock_get('simple_get')
     get '/simple_get'
-    expect { expect_json_types(bad: :bool) }.to raise_error
+    expect { expect_json_types(bad: :bool) }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 
   it 'should not fail when optional property is not present' do
@@ -34,7 +34,7 @@ describe 'expect_json_types' do
   it 'should ensure all valid types in a simple array' do
     mock_get('array_of_values')
     get '/array_of_values'
-    expect { expect_json_types(bad: :array_of_ints) }.to raise_error
+    expect { expect_json_types(bad: :array_of_ints) }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 
   it 'should allow empty array' do

--- a/spec/airborne/expectations/expect_status_spec.rb
+++ b/spec/airborne/expectations/expect_status_spec.rb
@@ -10,7 +10,7 @@ describe 'expect_status' do
   it 'should fail when incorrect status code is returned' do
     mock_get('simple_get')
     get '/simple_get'
-    expect { expect_status 123 }.to raise_error
+    expect { expect_status 123 }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 
   it 'should translate symbol codes to whatever is appropriate for the request' do

--- a/spec/airborne/rack/rack_sinatra_spec.rb
+++ b/spec/airborne/rack/rack_sinatra_spec.rb
@@ -23,7 +23,7 @@ describe 'rack app' do
 
   it 'should ensure correct values from sinatra app' do
     get '/'
-    expect { expect_json_types(foo: :int) }.to raise_error
+    expect { expect_json_types(foo: :int) }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 
   it 'Should set json_body even when not using the airborne http requests' do


### PR DESCRIPTION
Hey! thanks for this project, I am thinking about contribute to this amazing tool, but when I forked the repo and ran the tests I get a lot of warnings. this PR fix that

This is the warning that I was getting:

> WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Instead consider providing a specific error class or message. This message can be supressed by setting: `RSpec::Expectations.configuration.warn_about_potential_false_positives = false`.
