### PR TITLE
Support multi-value headers in expect_header, expect_header_contains

### DIFF
--- a/lib/airborne/request_expectations.rb
+++ b/lib/airborne/request_expectations.rb
@@ -59,12 +59,24 @@ module Airborne
     private
 
     def expect_header_impl(key, content, contains = nil)
-      header = headers[key]
-      if header
+      content = content.downcase
+      header  = headers[key]
+
+      if header.is_a?(Array)
+        header  = header.map(&:downcase)
+
         if contains
-          expect(header.downcase).to include(content.downcase)
+          expect(header).to include(a_string_matching(content))
         else
-          expect(header.downcase).to eq(content.downcase)
+          expect(header).to include(content)
+        end
+      elsif header
+        header = header.downcase
+
+        if contains
+          expect(header).to include(content)
+        else
+          expect(header).to eq(content)
         end
       else
         fail RSpec::Expectations::ExpectationNotMetError, "Header #{key} not present in HTTP response"

--- a/spec/airborne/expectations/expect_header_contains_spec.rb
+++ b/spec/airborne/expectations/expect_header_contains_spec.rb
@@ -18,4 +18,18 @@ describe 'expect header contains' do
     get '/simple_get'
     expect { expect_header_contains(:content_type, 'bar') }.to raise_error
   end
+
+  describe 'with multi-value headers' do
+    it 'should ensure partial header match exists' do
+      mock_get('simple_get', 'Set-Cookie' => ['cookie-name=myvalue; Path=/', 'another=value;'])
+      get '/simple_get'
+      expect_header_contains(:set_cookie, 'another=')
+    end
+
+    it 'should ensure partial header is present' do
+      mock_get('simple_get', 'Set-Cookie' => ['cookie-name=myvalue; Path=/', 'another=value;'])
+      get '/simple_get'
+      expect { expect_header_contains(:set_cookie, 'bar') }.to raise_error
+    end
+  end
 end

--- a/spec/airborne/expectations/expect_header_spec.rb
+++ b/spec/airborne/expectations/expect_header_spec.rb
@@ -18,4 +18,18 @@ describe 'expect header' do
     get '/simple_get'
     expect { expect_header(:foo, 'bar') }.to raise_error
   end
+
+  describe 'with multi-value headers' do
+    it 'should find exact match for header content' do
+      mock_get('simple_get', 'Set-Cookie' => ['cookie-name=myvalue; Path=/', 'another=value;'])
+      get '/simple_get'
+      expect_header(:set_cookie, 'cookie-name=myvalue; Path=/')
+    end
+
+    it 'should find exact match for header content' do
+      mock_get('simple_get', 'Set-Cookie' => ['cookie-name=myvalue; Path=/', 'another=value;'])
+      get '/simple_get'
+      expect { expect_header(:set_cookie, 'another=') }.to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Some response headers, like Set-Cookie, can be specified multiple times. That results in an array of values. Calling `expect_header` or `expect_header_contains` against one of these headers causes an exception:

````
Failure/Error: expect_header_contains(:set_cookie, 'foo')
NoMethodError:
  undefined method `downcase' for #<Array:0x007f9d811b64c8>
````

This patch adds support for headers with multiple values, checking the expectation against each value in the list and passing if any one value passes.