### PR TITLE
Fix Ariborne default content_type override to :json

### DIFF
--- a/lib/airborne/rest_client_requester.rb
+++ b/lib/airborne/rest_client_requester.rb
@@ -3,25 +3,29 @@ require 'rest_client'
 module Airborne
   module RestClientRequester
     def make_request(method, url, options = {})
-      headers = { content_type: :json }.merge(options[:headers] || {})
-      base_headers = Airborne.configuration.headers || {}
-      headers = base_headers.merge(headers)
+      headers = base_headers.merge(options[:headers] || {})
       res = if method == :post || method == :patch || method == :put
-              begin
-                request_body = options[:body].nil? ? '' : options[:body]
-                request_body = request_body.to_json if options[:body].is_a?(Hash)
-                RestClient.send(method, get_url(url), request_body, headers)
-              rescue RestClient::Exception => e
-                e.response
-              end
-            else
-              begin
-                RestClient.send(method, get_url(url), headers)
-              rescue RestClient::Exception => e
-                e.response
-              end
-            end
+        begin
+          request_body = options[:body].nil? ? '' : options[:body]
+          request_body = request_body.to_json if options[:body].is_a?(Hash)
+          RestClient.send(method, get_url(url), request_body, headers)
+        rescue RestClient::Exception => e
+          e.response
+        end
+      else
+        begin
+          RestClient.send(method, get_url(url), headers)
+        rescue RestClient::Exception => e
+          e.response
+        end
+      end
       res
+    end
+
+    private
+
+    def base_headers
+      { content_type: :json }.merge(Airborne.configuration.headers || {})
     end
   end
 end

--- a/spec/airborne/client_requester_spec.rb
+++ b/spec/airborne/client_requester_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'client requester' do
+  before do
+    allow(RestClient).to receive(:send)
+    RSpec::Mocks.space.proxy_for(self).remove_stub_if_present(:get)
+  end
+
+  after do
+    allow(RestClient).to receive(:send).and_call_original
+    Airborne.configure { |config| config.headers =  {} }
+  end
+
+  it 'should set :content_type to :json by default' do
+    get '/foo'
+
+    expect(RestClient).to have_received(:send)
+                            .with(:get, 'http://www.example.com/foo', { content_type: :json })
+  end
+
+  it 'should override headers with option[:headers]' do
+    get '/foo', { content_type: 'application/x-www-form-urlencoded' }
+
+    expect(RestClient).to have_received(:send)
+                            .with(:get, 'http://www.example.com/foo', { content_type: 'application/x-www-form-urlencoded' })
+  end
+
+  it 'should override headers with airborne config headers' do
+    Airborne.configure { |config| config.headers = { content_type: 'text/plain' } }
+
+    get '/foo'
+
+    expect(RestClient).to have_received(:send)
+                            .with(:get, 'http://www.example.com/foo', { content_type: 'text/plain' })
+  end
+end


### PR DESCRIPTION
When setting a global content type from Airborne config 
 
```ruby
Airborne.configure do |config|
  config.headers =  { content_type: 'text/plain' } 
end
```

It was overrided by [here](https://github.com/brooklynDev/airborne/blob/master/lib/airborne/rest_client_requester.rb#L8)

This commit fix this behavior, which was discribe in #64 