### PR TITLE
Pass raw hash to rest_client to allow multipart feature to work.

### DIFF
--- a/lib/airborne/rest_client_requester.rb
+++ b/lib/airborne/rest_client_requester.rb
@@ -6,9 +6,7 @@ module Airborne
       headers = base_headers.merge(options[:headers] || {})
       res = if method == :post || method == :patch || method == :put
         begin
-          request_body = options[:body].nil? ? '' : options[:body]
-          request_body = request_body.to_json if options[:body].is_a?(Hash)
-          RestClient.send(method, get_url(url), request_body, headers)
+          RestClient.send(method, get_url(url), options[:body] || '', headers)
         rescue RestClient::Exception => e
           e.response
         end


### PR DESCRIPTION
Without this change, I don't know of any way to get multipart bodies to work. Unless I'm mistaken, the json encoding was superfluous, as it's done by rest_client anyway.