### PR TITLE
Add support for payload on rest-client DELETE requests

### DIFF
--- a/lib/airborne/rest_client_requester.rb
+++ b/lib/airborne/rest_client_requester.rb
@@ -4,11 +4,15 @@ module Airborne
   module RestClientRequester
     def make_request(method, url, options = {})
       headers = base_headers.merge(options[:headers] || {})
-      res = if method == :post || method == :patch || method == :put
+      res = if method == :post || method == :patch || method == :put || method == :delete
         begin
           request_body = options[:body].nil? ? '' : options[:body]
           request_body = request_body.to_json if options[:body].is_a?(Hash)
-          RestClient.send(method, get_url(url), request_body, headers)
+          if method == :delete
+            RestClient::Request.execute(method: method, url: get_url(url), payload: request_body, headers: headers)
+          else
+            RestClient.send(method, get_url(url), request_body, headers)
+          end
         rescue RestClient::Exception => e
           e.response
         end


### PR DESCRIPTION
DELETE payload is already supported in rack requests via d8a515e these changes allow the functionality to work with rest-client requests.

Unfortunately payloads in DELETE requests are not currently supported in the rest-client delete helper method so I'm using `Request.execute` as [recommended in their docs](https://github.com/rest-client/rest-client#passing-advanced-options)
