### PR TITLE
date_or_null fix

### DIFF
--- a/lib/airborne/request_expectations.rb
+++ b/lib/airborne/request_expectations.rb
@@ -101,7 +101,7 @@ module Airborne
 
       @mapper ||= get_mapper
 
-      actual = convert_to_date(actual) if expected == :date
+      actual = convert_to_date(actual) if ((expected == :date) || (expected == :date_or_null))
 
       return expect_type(expected, actual.class) if expected.is_a?(Symbol)
       return expected.call(actual) if expected.is_a?(Proc)
@@ -115,7 +115,7 @@ module Airborne
       keys.flatten.uniq.each do |prop|
         type  = extract_expected_type(expected, prop)
         value = extract_actual(actual, prop)
-        value = convert_to_date(value) if type == :date
+        value = convert_to_date(value) if ((type == :date) || (type == :date_or_null))
 
         next expect_json_types_impl(type, value) if hash?(type)
         next type.call(value) if type.is_a?(Proc)

--- a/spec/airborne/expectations/expect_json_types_date_spec.rb
+++ b/spec/airborne/expectations/expect_json_types_date_spec.rb
@@ -24,3 +24,29 @@ describe 'expect_json with date' do
     expect_json(createdAt: date { |value| expect(value).to be_between(prev_day, next_day) })
   end
 end
+
+describe 'expect_json_types with date_or_null' do
+  it 'should verify date_or_null when date is null' do
+    mock_get('date_is_null_response')
+    get '/date_is_null_response'
+    expect_json_types(dateDeleted: :date_or_null)
+  end
+
+  it 'should verify date_or_null when date is null with path' do
+    mock_get('date_is_null_response')
+    get '/date_is_null_response'
+    expect_json_types('dateDeleted', :date_or_null)
+  end
+
+  it 'should verify date_or_null with date' do
+    mock_get('date_response')
+    get '/date_response'
+    expect_json_types(createdAt: :date_or_null)
+  end
+
+  it 'should verify date_or_null with date with path' do
+    mock_get('date_response')
+    get '/date_response'
+    expect_json_types('createdAt', :date_or_null)
+  end
+end

--- a/spec/test_responses/date_is_null_response.json
+++ b/spec/test_responses/date_is_null_response.json
@@ -1,0 +1,3 @@
+{
+	"dateDeleted": null
+}


### PR DESCRIPTION
_fix:_ `expect_json_types` when type is `:date_or_null` and actual value is `null`
Includes tests to validate change

Dates may be `null` until specifically set; example response: `{"dateDeleted": null}`
This patch corrects invalid type failure when response is a valid date; example response:
 `{"dateDeleted": "2009-12-09T06:00:00Z"}` and expected type is `:date_or_null`
