### PR TITLE
Replace Fixnum and Bignum with Integer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 rvm:
   - 2.2.3
   - 2.3.1
+  - 2.4.1
 
 script: bundle exec rspec spec
 before_install:

--- a/lib/airborne/request_expectations.rb
+++ b/lib/airborne/request_expectations.rb
@@ -231,17 +231,17 @@ module Airborne
     end
 
     def property?(expectations)
-      [String, Regexp, Float, Fixnum, Bignum, TrueClass, FalseClass, NilClass, Array].include?(expectations.class)
+      [String, Regexp, Float, *integer_types, TrueClass, FalseClass, NilClass, Array].include?(expectations.class)
     end
 
     def get_mapper
       base_mapper = {
-        integer: [Fixnum, Bignum],
-        array_of_integers: [Fixnum, Bignum],
-        int: [Fixnum, Bignum],
-        array_of_ints: [Fixnum, Bignum],
-        float: [Float, Fixnum, Bignum],
-        array_of_floats: [Float, Fixnum, Bignum],
+        integer: integer_types,
+        array_of_integers: integer_types,
+        int: integer_types,
+        array_of_ints: integer_types,
+        float: [Float, *integer_types],
+        array_of_floats: [Float, *integer_types],
         string: [String],
         array_of_strings: [String],
         boolean: [TrueClass, FalseClass],
@@ -282,6 +282,14 @@ module Airborne
 
     def match_expected?
       Airborne.configuration.match_expected?
+    end
+
+    def integer_types
+      if 0.class == Integer
+        [Integer]
+      else
+        [Fixnum, Bignum]
+      end
     end
   end
 end


### PR DESCRIPTION
Ruby 2.4 deprecated the use of both Fixnum and Bignum, instead
encouraging everyone to just use Integer, which is their superclass.

So, we can replace all instances of the two deprecated classes with just
Integer, silencing the warnings from this library when on Ruby 2.4.X.

It looks like this exact change has been opened twice, and then immediately closed out by the owners? Is there a reason for this?

https://bugs.ruby-lang.org/issues/12005