### PR TITLE
pass block to RestClient method for better response handling

### DIFF
--- a/lib/airborne/rest_client_requester.rb
+++ b/lib/airborne/rest_client_requester.rb
@@ -8,13 +8,13 @@ module Airborne
         begin
           request_body = options[:body].nil? ? '' : options[:body]
           request_body = request_body.to_json if options[:body].is_a?(Hash)
-          RestClient.send(method, get_url(url), request_body, headers)
+          RestClient.send(method, get_url(url), request_body, headers){|response, request, result| response }
         rescue RestClient::Exception => e
           e.response
         end
       else
         begin
-          RestClient.send(method, get_url(url), headers)
+          RestClient.send(method, get_url(url), headers){|response, request, result| response }
         rescue RestClient::Exception => e
           e.response
         end


### PR DESCRIPTION
RestClient is sometimes a bit quirky with error handling; most especially with non-success responses.
When writing tests specifically dealing with error or bad request responses it is desired that the actual response is [always] returned.

By passing a block to the RestClient method we will now always return the actual response.

I would have added tests for this change, but there are no obvious tests that would cover this change.

The change submitted retains the original error handling and simply plugs the hole when RestClient 'blows up' when it really shouldn't be (the quirky error handling).

An alternate change would be to remove the current error handling; I tested both changes, but felt that retaining the existing error handling was the more, Airborne, consistent change.

By way of real-world testing, this changes matches our own, internal, generic wrapper for RestClient and has successfully corrected numerous problems we have encountered with our tests.