### PR TITLE
Rspec 3.5 compatibility

### DIFF
--- a/lib/airborne.rb
+++ b/lib/airborne.rb
@@ -6,7 +6,6 @@ require 'airborne/rack_test_requester'
 require 'airborne/base'
 
 RSpec.configure do |config|
-  config.include Airborne
   config.add_setting :base_url
   config.add_setting :match_expected
   config.add_setting :match_actual
@@ -22,4 +21,7 @@ RSpec.configure do |config|
     config.match_actual = example.metadata[:match_actual].nil? ?
       Airborne.configuration.match_actual_default? : example.metadata[:match_actual]
   end
+
+  # Include last since it depends on the configuration already being added
+  config.include Airborne
 end


### PR DESCRIPTION
Previously Airborne.base was loaded before the configuration was added.
This caused an error:

```
Gem Load Error is: undefined method `requester_module' for
```

Waiting to load Airborne.base until the configuration has been added (`
config.add_setting :requester_module`) fixes the issue.

Fixes #121