### PR TITLE
Add curl command

### DIFF
--- a/lib/airborne.rb
+++ b/lib/airborne.rb
@@ -2,6 +2,7 @@ require 'airborne/optional_hash_type_expectations'
 require 'airborne/path_matcher'
 require 'airborne/request_expectations'
 require 'airborne/rest_client_requester'
+require 'airborne/curl_command_builder'
 require 'airborne/rack_test_requester'
 require 'airborne/base'
 

--- a/lib/airborne/base.rb
+++ b/lib/airborne/base.rb
@@ -6,6 +6,7 @@ module Airborne
   class InvalidJsonError < StandardError; end
 
   include RequestExpectations
+  include CurlCommandBuilder
 
   attr_reader :response, :headers, :body
 
@@ -71,6 +72,10 @@ module Airborne
 
   def json_body
     JSON.parse(response.body, symbolize_names: true) rescue fail InvalidJsonError, 'Api request returned invalid json'
+  end
+
+  def curl
+    curl_command
   end
 
   private

--- a/lib/airborne/curl_command_builder.rb
+++ b/lib/airborne/curl_command_builder.rb
@@ -1,0 +1,28 @@
+require 'shellwords'
+
+module Airborne
+  module CurlCommandBuilder
+
+    def curl_command
+      [
+        'curl -v',
+        ['-d', @request_body].shelljoin,
+        "-X#{@method.to_s.upcase}",
+        build_headers(@headers),
+        get_url(@url)
+      ].join ' '
+    end
+
+    private
+
+    def build_headers(headers)
+      base_headers.merge(headers).map { |header, value|
+        header = header.to_s.split('_').map(&:capitalize).join('-')
+        [
+          '-H',
+          "\"#{header}: #{value}\""
+        ].shelljoin
+      }.join ' '
+    end
+  end
+end

--- a/lib/airborne/rest_client_requester.rb
+++ b/lib/airborne/rest_client_requester.rb
@@ -4,10 +4,16 @@ module Airborne
   module RestClientRequester
     def make_request(method, url, options = {})
       headers = base_headers.merge(options[:headers] || {})
+      @method = method
+      @url = url
+      @options = options
+      @headers = headers
+      @request_body = ''
       res = if method == :post || method == :patch || method == :put
         begin
           request_body = options[:body].nil? ? '' : options[:body]
           request_body = request_body.to_json if options[:body].is_a?(Hash)
+          @request_body = request_body
           RestClient.send(method, get_url(url), request_body, headers)
         rescue RestClient::Exception => e
           e.response

--- a/spec/airborne/curl_spec.rb
+++ b/spec/airborne/curl_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'curl command spec' do
+  it 'when a GET request is made curl should provide correct equivalent' do
+    mock_get('simple_get')
+    get '/simple_get'
+
+    expect(curl).to eq('curl -v -d \'\' -XGET -H \"Content-Type:\ json\" http://www.example.com/simple_get')
+  end
+
+  it 'when a POST request is made curl should provide correct equivalent' do
+    mock_post('simple_post')
+    body = { test: "value", bool: true }
+    post '/simple_post', body, { x_header: "is it?" }
+
+    expect(curl).to eq('curl -v -d \{\"test\":\"value\",\"bool\":true\} -XPOST -H \"Content-Type:\ json\" -H \"X-Header:\ is\ it\?\" http://www.example.com/simple_post')
+  end
+end


### PR DESCRIPTION
When playing tests, I sometimes need to manually investigate the behaviour of a specific API.
Instead of tweaking spec code, I rather reproduce the request with cURL.

This commit adds a `curl` method that generates a valid curl command to replay the just previous request.

Usage:
```ruby
it "does your thing" do
  post '/somewhere', { some: "json" }
  # ...
  curl
  # will output:
  # curl -v -d \{\"some\":\"json\"\} -XPOST http://yourserver/somewhere
end
```

A complement could be to have this as an optional behavior; that is: anytime a feature test fails, if the option is set, it outputs the curl command to suggest how to further investigate the failing case. Not so sure how to implement that at this point.

Now:
* I am not sure this is even going to be relevant for everyone; I found it helped me, because I had to tinker with some unstable APIs, in a not fully automated test setup. I would totally understand if that feels unnecessary to add.
* I am not very satisfied either with the added instance vars in `make_request`; at least, done this way; maybe because it's redundant.