### PR TITLE
Serialize to JSON when content type is set to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,17 @@ When calling any of the methods above, you can pass request headers to be used.
 get 'http://example.com/api/v1/my_api', { 'x-auth-token' => 'my_token' }
 ```
 
-For requests that require a body (`post`, `put`, `patch`) you can pass the body as a hash as well:
+For requests that require a body (`post`, `put`, `patch`) you can pass the body as well:
 
 ```ruby
 post 'http://example.com/api/v1/my_api', { :name => 'John Doe' }, { 'x-auth-token' => 'my_token' }
+```
+
+The body may be any JSON-serializable type, as long as you want to post `application/json` content type.
+You may set a different content type and post a string body this way:
+
+```ruby
+post 'http://example.com/api/v1/my_api', "Hello there!", { content_type: 'text/plain' }
 ```
 
 For requests that require Query params you can pass a params hash into headers.

--- a/lib/airborne/rest_client_requester.rb
+++ b/lib/airborne/rest_client_requester.rb
@@ -25,7 +25,8 @@ module Airborne
     private
 
     def is_json_request(headers)
-      headers.fetch(:content_type) == :json
+      header = headers.fetch(:content_type)
+      header == :json || /application\/([a-zA-Z0-9\.\_\-]*\+?)json/ =~ header
     end
 
     def base_headers

--- a/lib/airborne/rest_client_requester.rb
+++ b/lib/airborne/rest_client_requester.rb
@@ -7,7 +7,7 @@ module Airborne
       res = if method == :post || method == :patch || method == :put
         begin
           request_body = options[:body].nil? ? '' : options[:body]
-          request_body = request_body.to_json if options[:body].is_a?(Hash)
+          request_body = request_body.to_json if is_json_request(headers)
           RestClient.send(method, get_url(url), request_body, headers)
         rescue RestClient::Exception => e
           e.response
@@ -23,6 +23,10 @@ module Airborne
     end
 
     private
+
+    def is_json_request(headers)
+      headers.fetch(:content_type) == :json
+    end
 
     def base_headers
       { content_type: :json }.merge(Airborne.configuration.headers || {})

--- a/spec/airborne/client_requester_spec.rb
+++ b/spec/airborne/client_requester_spec.rb
@@ -34,14 +34,21 @@ describe 'client requester' do
                             .with(:get, 'http://www.example.com/foo', { content_type: 'text/plain' })
   end
 
-  it 'should serialize body to json when :content_type is :json' do
+  it 'should serialize body to json when :content_type is (default) :json' do
     post '/foo', { test: 'serialized' }
 
     expect(RestClient).to have_received(:send)
                             .with(:post, 'http://www.example.com/foo', '{"test":"serialized"}', { content_type: :json })
   end
 
-  it 'should not serialize body to json when :content_type is not :json' do
+  it 'should serialize body to json when :content_type is any enhanced JSON content type' do
+    post '/foo', { test: 'serialized' }, { content_type: 'application/vnd.airborne.2+json' }
+
+    expect(RestClient).to have_received(:send)
+                            .with(:post, 'http://www.example.com/foo', '{"test":"serialized"}', { content_type: 'application/vnd.airborne.2+json' })
+  end
+
+  it 'should not serialize body to json when :content_type does not match JSON' do
     post '/foo', { test: 'not serialized' }, { content_type: 'text/plain' }
 
     expect(RestClient).to have_received(:send)

--- a/spec/airborne/client_requester_spec.rb
+++ b/spec/airborne/client_requester_spec.rb
@@ -33,4 +33,18 @@ describe 'client requester' do
     expect(RestClient).to have_received(:send)
                             .with(:get, 'http://www.example.com/foo', { content_type: 'text/plain' })
   end
+
+  it 'should serialize body to json when :content_type is :json' do
+    post '/foo', { test: 'serialized' }
+
+    expect(RestClient).to have_received(:send)
+                            .with(:post, 'http://www.example.com/foo', '{"test":"serialized"}', { content_type: :json })
+  end
+
+  it 'should not serialize body to json when :content_type is not :json' do
+    post '/foo', { test: 'not serialized' }, { content_type: 'text/plain' }
+
+    expect(RestClient).to have_received(:send)
+                            .with(:post, 'http://www.example.com/foo', { test: 'not serialized' }, { content_type: 'text/plain' })
+  end
 end


### PR DESCRIPTION
Until now, the request body is only serialized if it's a Hash.
But it could be an Array, or any other serializable type and those bodies are serialized.
See #129, probably #141 as well.

I am not sure if this wouldn't break use cases where the body is already expected to be serialized.