### PR TITLE
configure dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+version: 1
+
+update_configs:
+  - package_manager: "ruby:bundler"
+    directory: "./"
+    update_schedule: "daily"
+    # https://dependabot.com/docs/config-file/#version_requirement_updates
+    version_requirement_updates: auto


### PR DESCRIPTION
In case @brooklynDev approves [Dependabot](https://dependabot.com/), here's a config to manage it.

- Dependabot will use the `airborne.gemspec` to determine dependency version ranges
- The `version_requirement_updates: auto` config will loosen the version ranges as new versions become available