### PR TITLE
create verify_ssl config

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ describe 'test something' do
 end
 ```
 
+This feature currently isn't supported when testing loaded Rack applications (see "Testing Rack Applications" below). If you need to set `verify_ssl: false`, then we recommend starting your Rack app server and sending the `airborne` HTTP requests as you would when testing any other service.
+
 ## Testing Rack Applications
 
 If you have an existing Rack application like `sinatra` or `grape` you can run Airborne against your application and test without actually having a server running. To do that, just specify your rack application in your Airborne configuration:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Airborne 
+# Airborne
 
 [![airborne travis](http://img.shields.io/travis/brooklynDev/airborne.svg?branch=master&style=flat-square)](https://travis-ci.org/brooklynDev/airborne)
 [![airborne coveralls](http://img.shields.io/coveralls/brooklynDev/airborne/master.svg?style=flat-square)](https://coveralls.io/r/brooklynDev/airborne?branch=master)
@@ -156,6 +156,51 @@ For requests that require Query params you can pass a params hash into headers.
 post 'http://example.com/api/v1/my_api', { }, { 'params' => {'param_key' => 'param_value' } }
 ```
 
+### (Not) Verifying SSL Certificates
+
+SSL certificate verification is enabled by default (specifically, `OpenSSL::SSL::VERIFY_PEER`). You can override this behavior per request:
+
+```ruby
+verify_ssl = false
+post 'http://example.com/api/v1/my_api', "Hello there!", { content_type: 'text/plain' }, verify_ssl
+```
+
+or with a global Airborne configuration:
+
+```ruby
+Airborne.configure do |config|
+  config.verify_ssl = false # equivalent to OpenSSL::SSL::VERIFY_NONE
+end
+```
+
+Note the per-request option always overrides the Airborne configuration:
+
+```ruby
+before do
+  Airborne.configuration.verify_ssl = false
+end
+
+it 'will still verify the SSL certificate' do
+  verify_ssl = true
+  post 'http://example.com/api/v1/my_api', "Hello there!", { content_type: 'text/plain' }, verify_ssl
+end
+```
+
+You can use the `verify_ssl` setting to override your global defaults in test blocks like this:
+
+```ruby
+describe 'test something', verify_ssl: false do
+end
+```
+
+OR
+
+```ruby
+describe 'test something' do
+  Airborne.configuration.verify_ssl = false
+end
+```
+
 ## Testing Rack Applications
 
 If you have an existing Rack application like `sinatra` or `grape` you can run Airborne against your application and test without actually having a server running. To do that, just specify your rack application in your Airborne configuration:
@@ -238,7 +283,7 @@ it 'should allow nested paths' do
 end
 ```
 
-Alternativley, if we only want to test `coordinates` we can dot into just the `coordinates`:
+Alternatively, if we only want to test `coordinates` we can dot into just the `coordinates`:
 
 ```ruby
 it 'should allow nested paths' do

--- a/README.md
+++ b/README.md
@@ -158,7 +158,11 @@ post 'http://example.com/api/v1/my_api', { }, { 'params' => {'param_key' => 'par
 
 ### (Not) Verifying SSL Certificates
 
-SSL certificate verification is enabled by default (specifically, `OpenSSL::SSL::VERIFY_PEER`). You can override this behavior per request:
+SSL certificate verification is enabled by default (specifically, `OpenSSL::SSL::VERIFY_PEER`).
+
+Carefully consider how you use this. It's not a solution for getting around a failed SSL cert verification; rather, it's intended for testing systems that don't have a legitimate SSL cert, such as a development or test environment.
+
+You can override this behavior per request:
 
 ```ruby
 verify_ssl = false

--- a/lib/airborne.rb
+++ b/lib/airborne.rb
@@ -15,11 +15,14 @@ RSpec.configure do |config|
   config.add_setting :rack_app
   config.add_setting :requester_type
   config.add_setting :requester_module
+  config.add_setting :verify_ssl, default: true
   config.before do |example|
     config.match_expected = example.metadata[:match_expected].nil? ?
       Airborne.configuration.match_expected_default? : example.metadata[:match_expected]
     config.match_actual = example.metadata[:match_actual].nil? ?
       Airborne.configuration.match_actual_default? : example.metadata[:match_actual]
+    config.verify_ssl = example.metadata[:verify_ssl].nil? ?
+      Airborne.configuration.verify_ssl? : example.metadata[:verify_ssl]
   end
 
   # Include last since it depends on the configuration already being added

--- a/lib/airborne/base.rb
+++ b/lib/airborne/base.rb
@@ -29,24 +29,24 @@ module Airborne
     RSpec.configuration
   end
 
-  def get(url, headers = nil)
-    @response = make_request(:get, url, headers: headers)
+  def get(url, headers = nil, verify_ssl = base_verify_ssl)
+    @response = make_request(:get, url, headers: headers, verify_ssl: verify_ssl)
   end
 
-  def post(url, post_body = nil, headers = nil)
-    @response = make_request(:post, url, body: post_body, headers: headers)
+  def post(url, post_body = nil, headers = nil, verify_ssl = base_verify_ssl)
+    @response = make_request(:post, url, body: post_body, headers: headers, verify_ssl: verify_ssl)
   end
 
-  def patch(url, patch_body = nil, headers = nil)
-    @response = make_request(:patch, url, body: patch_body, headers: headers)
+  def patch(url, patch_body = nil, headers = nil, verify_ssl = base_verify_ssl)
+    @response = make_request(:patch, url, body: patch_body, headers: headers, verify_ssl: verify_ssl)
   end
 
-  def put(url, put_body = nil, headers = nil)
-    @response = make_request(:put, url, body: put_body, headers: headers)
+  def put(url, put_body = nil, headers = nil, verify_ssl = base_verify_ssl)
+    @response = make_request(:put, url, body: put_body, headers: headers, verify_ssl: verify_ssl)
   end
 
-  def delete(url, delete_body = nil, headers = nil)
-    @response = make_request(:delete, url, body: delete_body, headers: headers)
+  def delete(url, delete_body = nil, headers = nil, verify_ssl = base_verify_ssl)
+    @response = make_request(:delete, url, body: delete_body, headers: headers, verify_ssl: verify_ssl)
   end
 
   def head(url, headers = nil)
@@ -78,5 +78,9 @@ module Airborne
   def get_url(url)
     base = Airborne.configuration.base_url || ''
     base + url
+  end
+
+  def base_verify_ssl
+    Airborne.configuration.verify_ssl || false
   end
 end

--- a/lib/airborne/rest_client_requester.rb
+++ b/lib/airborne/rest_client_requester.rb
@@ -8,13 +8,22 @@ module Airborne
         begin
           request_body = options[:body].nil? ? '' : options[:body]
           request_body = request_body.to_json if is_json_request(headers)
-          RestClient.send(method, get_url(url), request_body, headers){|response, request, result| response }
+          RestClient::Request.execute(
+            method: method,
+            url: get_url(url),
+            payload: request_body,
+            headers: headers
+          ) { |response, request, result| response }
         rescue RestClient::Exception => e
           e.response
         end
       else
         begin
-          RestClient.send(method, get_url(url), headers){|response, request, result| response }
+          RestClient::Request.execute(
+            method: method,
+            url: get_url(url),
+            headers: headers
+          ) { |response, request, result| response }
         rescue RestClient::Exception => e
           e.response
         end

--- a/lib/airborne/rest_client_requester.rb
+++ b/lib/airborne/rest_client_requester.rb
@@ -4,6 +4,7 @@ module Airborne
   module RestClientRequester
     def make_request(method, url, options = {})
       headers = base_headers.merge(options[:headers] || {})
+      verify_ssl = options.fetch(:verify_ssl, true)
       res = if method == :post || method == :patch || method == :put
         begin
           request_body = options[:body].nil? ? '' : options[:body]
@@ -12,7 +13,8 @@ module Airborne
             method: method,
             url: get_url(url),
             payload: request_body,
-            headers: headers
+            headers: headers,
+            verify_ssl: verify_ssl
           ) { |response, request, result| response }
         rescue RestClient::Exception => e
           e.response
@@ -22,7 +24,8 @@ module Airborne
           RestClient::Request.execute(
             method: method,
             url: get_url(url),
-            headers: headers
+            headers: headers,
+            verify_ssl: verify_ssl
           ) { |response, request, result| response }
         rescue RestClient::Exception => e
           e.response

--- a/spec/airborne/client_requester_spec.rb
+++ b/spec/airborne/client_requester_spec.rb
@@ -2,27 +2,33 @@ require 'spec_helper'
 
 describe 'client requester' do
   before do
-    allow(RestClient).to receive(:send)
+    allow(RestClient::Request).to receive(:execute)
     RSpec::Mocks.space.proxy_for(self).remove_stub_if_present(:get)
   end
 
   after do
-    allow(RestClient).to receive(:send).and_call_original
+    allow(RestClient::Request).to receive(:execute).and_call_original
     Airborne.configure { |config| config.headers =  {} }
   end
 
   it 'should set :content_type to :json by default' do
     get '/foo'
 
-    expect(RestClient).to have_received(:send)
-                            .with(:get, 'http://www.example.com/foo', { content_type: :json })
+    expect(RestClient::Request).to have_received(:execute).with(
+      method: :get,
+      url: 'http://www.example.com/foo',
+      headers: { content_type: :json }
+    )
   end
 
   it 'should override headers with option[:headers]' do
     get '/foo', { content_type: 'application/x-www-form-urlencoded' }
 
-    expect(RestClient).to have_received(:send)
-                            .with(:get, 'http://www.example.com/foo', { content_type: 'application/x-www-form-urlencoded' })
+    expect(RestClient::Request).to have_received(:execute).with(
+      method: :get,
+      url: 'http://www.example.com/foo',
+      headers: { content_type: 'application/x-www-form-urlencoded' }
+    )
   end
 
   it 'should override headers with airborne config headers' do
@@ -30,28 +36,43 @@ describe 'client requester' do
 
     get '/foo'
 
-    expect(RestClient).to have_received(:send)
-                            .with(:get, 'http://www.example.com/foo', { content_type: 'text/plain' })
+    expect(RestClient::Request).to have_received(:execute).with(
+      method: :get,
+      url: 'http://www.example.com/foo',
+      headers: { content_type: 'text/plain' }
+    )
   end
 
   it 'should serialize body to json when :content_type is (default) :json' do
     post '/foo', { test: 'serialized' }
 
-    expect(RestClient).to have_received(:send)
-                            .with(:post, 'http://www.example.com/foo', '{"test":"serialized"}', { content_type: :json })
+    expect(RestClient::Request).to have_received(:execute).with(
+      method: :post,
+      url: 'http://www.example.com/foo',
+      payload: { test: 'serialized' }.to_json,
+      headers: { content_type: :json }
+    )
   end
 
   it 'should serialize body to json when :content_type is any enhanced JSON content type' do
     post '/foo', { test: 'serialized' }, { content_type: 'application/vnd.airborne.2+json' }
 
-    expect(RestClient).to have_received(:send)
-                            .with(:post, 'http://www.example.com/foo', '{"test":"serialized"}', { content_type: 'application/vnd.airborne.2+json' })
+    expect(RestClient::Request).to have_received(:execute).with(
+      method: :post,
+      url: 'http://www.example.com/foo',
+      payload: { test: 'serialized' }.to_json,
+      headers: { content_type: 'application/vnd.airborne.2+json' }
+    )
   end
 
   it 'should not serialize body to json when :content_type does not match JSON' do
     post '/foo', { test: 'not serialized' }, { content_type: 'text/plain' }
 
-    expect(RestClient).to have_received(:send)
-                            .with(:post, 'http://www.example.com/foo', { test: 'not serialized' }, { content_type: 'text/plain' })
+    expect(RestClient::Request).to have_received(:execute).with(
+      method: :post,
+      url: 'http://www.example.com/foo',
+      payload: { test: 'not serialized' },
+      headers: { content_type: 'text/plain' }
+    )
   end
 end

--- a/spec/airborne/client_requester_spec.rb
+++ b/spec/airborne/client_requester_spec.rb
@@ -8,7 +8,8 @@ describe 'client requester' do
 
   after do
     allow(RestClient::Request).to receive(:execute).and_call_original
-    Airborne.configure { |config| config.headers =  {} }
+    Airborne.configure { |config| config.headers = {} }
+    Airborne.configure { |config| config.verify_ssl = true }
   end
 
   it 'should set :content_type to :json by default' do
@@ -17,7 +18,8 @@ describe 'client requester' do
     expect(RestClient::Request).to have_received(:execute).with(
       method: :get,
       url: 'http://www.example.com/foo',
-      headers: { content_type: :json }
+      headers: { content_type: :json },
+      verify_ssl: true
     )
   end
 
@@ -27,7 +29,8 @@ describe 'client requester' do
     expect(RestClient::Request).to have_received(:execute).with(
       method: :get,
       url: 'http://www.example.com/foo',
-      headers: { content_type: 'application/x-www-form-urlencoded' }
+      headers: { content_type: 'application/x-www-form-urlencoded' },
+      verify_ssl: true
     )
   end
 
@@ -39,7 +42,8 @@ describe 'client requester' do
     expect(RestClient::Request).to have_received(:execute).with(
       method: :get,
       url: 'http://www.example.com/foo',
-      headers: { content_type: 'text/plain' }
+      headers: { content_type: 'text/plain' },
+      verify_ssl: true
     )
   end
 
@@ -50,7 +54,8 @@ describe 'client requester' do
       method: :post,
       url: 'http://www.example.com/foo',
       payload: { test: 'serialized' }.to_json,
-      headers: { content_type: :json }
+      headers: { content_type: :json },
+      verify_ssl: true
     )
   end
 
@@ -61,7 +66,8 @@ describe 'client requester' do
       method: :post,
       url: 'http://www.example.com/foo',
       payload: { test: 'serialized' }.to_json,
-      headers: { content_type: 'application/vnd.airborne.2+json' }
+      headers: { content_type: 'application/vnd.airborne.2+json' },
+      verify_ssl: true
     )
   end
 
@@ -72,7 +78,108 @@ describe 'client requester' do
       method: :post,
       url: 'http://www.example.com/foo',
       payload: { test: 'not serialized' },
-      headers: { content_type: 'text/plain' }
+      headers: { content_type: 'text/plain' },
+      verify_ssl: true
     )
+  end
+
+  context 'verify_ssl' do
+    it 'should be true by default' do
+      get '/foo'
+
+      expect(RestClient::Request).to have_received(:execute).with(
+        method: :get,
+        url: 'http://www.example.com/foo',
+        headers: { content_type: :json },
+        verify_ssl: true
+      )
+    end
+
+    it 'should be set by airborne config' do
+      Airborne.configure { |config| config.verify_ssl = false }
+
+      get '/foo'
+
+      expect(RestClient::Request).to have_received(:execute).with(
+        method: :get,
+        url: 'http://www.example.com/foo',
+        headers: { content_type: :json },
+        verify_ssl: false
+      )
+    end
+
+    it 'should be overriden with options[:verify_ssl]' do
+      get '/foo', nil, false
+
+      expect(RestClient::Request).to have_received(:execute).with(
+        method: :get,
+        url: 'http://www.example.com/foo',
+        headers: { content_type: :json },
+        verify_ssl: false
+      )
+    end
+
+    it 'should override airborne config with options[:verify_ssl]' do
+      Airborne.configure { |config| config.verify_ssl = false }
+
+      get '/foo', nil, true
+
+      expect(RestClient::Request).to have_received(:execute).with(
+        method: :get,
+        url: 'http://www.example.com/foo',
+        headers: { content_type: :json },
+        verify_ssl: true
+      )
+    end
+
+    it 'should interpret airborne "config.verify_ssl = nil" as false' do
+      Airborne.configure { |config| config.verify_ssl = nil }
+
+      get '/foo'
+
+      expect(RestClient::Request).to have_received(:execute).with(
+        method: :get,
+        url: 'http://www.example.com/foo',
+        headers: { content_type: :json },
+        verify_ssl: false
+      )
+    end
+
+    context 'rspec metadata', verify_ssl: false do
+      it 'should override the base airborne config with the rspec metadata' do
+        get '/foo'
+
+        expect(RestClient::Request).to have_received(:execute).with(
+          method: :get,
+          url: 'http://www.example.com/foo',
+          headers: { content_type: :json },
+          verify_ssl: false
+        )
+      end
+
+      it 'should be overriden with options[:verify_ssl]' do
+        get '/foo', nil, true
+
+        expect(RestClient::Request).to have_received(:execute).with(
+          method: :get,
+          url: 'http://www.example.com/foo',
+          headers: { content_type: :json },
+          verify_ssl: true
+        )
+      end
+
+      it 'should be overriden by supplied airborne config' do
+        Airborne.configure { |config| config.verify_ssl = true }
+
+        get '/foo'
+
+        expect(RestClient::Request).to have_received(:execute).with(
+          method: :get,
+          url: 'http://www.example.com/foo',
+          headers: { content_type: :json },
+          verify_ssl: true
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
This should close issue #118 

A few notes on this PR:

1. I don't quite grok the `head` and `options` base methods, so I may have missed some necessary changes there.

2. I came across the following related report in the rest-client repo, but I couldn't reproduce the reported error with this PR in place. ¯\_(ツ)_/¯ https://github.com/rest-client/rest-client/issues/628

3. I wanted to refactor the base.rb methods to simplify the method parameters (for example, to avoid `get '/foo', nil, false` ... feels icky) and to allow passing any desired options down to RestClient, but decided against it. I think most users will be served by the `Airborne.configuration` and RSpec metadata tag for now.

4. The excellent [badssl.com](https://github.com/chromium/badssl.com) project lets us manually verify these changes actually work:

```ruby
RSpec.describe 'Bad SSL' do
  it 'does\'t verify the SSL certificate', verify_ssl: false do
    Airborne.configuration.base_url = 'https://self-signed.badssl.com'
    get '/'
    expect_status(200)
  end

  it 'tries to verify the SSL cert and returns a nil response', verify_ssl: true do
    Airborne.configuration.base_url = 'https://self-signed.badssl.com'
    get '/'
    expect(response).to be_nil
  end
end
```

Note they specifically recommend against using their servers for automated testing, so I didn't code a spec. I think having one would be a good addition though if y'all want to fork their repo and host a "bad ssl" server.

Let me know if anything needs changing!