### PR TITLE
Fix requests with IO body

### DIFF
--- a/lib/airborne/rest_client_requester.rb
+++ b/lib/airborne/rest_client_requester.rb
@@ -7,8 +7,8 @@ module Airborne
       verify_ssl = options.fetch(:verify_ssl, true)
       res = if method == :post || method == :patch || method == :put || method == :delete
         begin
-          request_body = options[:body].nil? || options[:body].empty? ? '' : options[:body]
-          request_body = request_body.to_json if is_json_request(headers) && !request_body.empty?
+          request_body = options[:body].nil? || is_empty(options[:body]) ? '' : options[:body]
+          request_body = request_body.to_json if is_json_request(headers) && !is_empty(request_body)
           RestClient::Request.execute(
             method: method,
             url: get_url(url),
@@ -39,6 +39,12 @@ module Airborne
     def is_json_request(headers)
       header = headers.fetch(:content_type)
       header == :json || /application\/([a-zA-Z0-9\.\_\-]*\+?)json/ =~ header
+    end
+
+    def is_empty(body)
+      return body.empty? if body.respond_to?(:empty?)
+
+      false
     end
 
     def base_headers

--- a/spec/airborne/post_spec.rb
+++ b/spec/airborne/post_spec.rb
@@ -14,4 +14,11 @@ describe 'post' do
     post '/simple_post', 'hello', content_type: 'text/plain'
     expect(WebMock).to have_requested(:post, url).with(body: 'hello', headers: { 'Content-Type' => 'text/plain' })
   end
+
+  it 'should allow testing on post requests with IO body' do
+    url = 'http://www.example.com/simple_post'
+    stub_request(:post, url)
+    post '/simple_post', StringIO.new('hello'), content_type: 'application/octet-stream'
+    expect(WebMock).to have_requested(:post, url).with(body: 'hello', headers: { 'Content-Type' => 'application/octet-stream' })
+  end
 end


### PR DESCRIPTION
Fix requests with IO body. Those currently fail with:

```
NoMethodError:
       undefined method `empty?' for #<StringIO:0x00007fd1e3b2a158>
```