### PR TITLE
Return original exception if response is not present

### DIFF
--- a/lib/airborne/rest_client_requester.rb
+++ b/lib/airborne/rest_client_requester.rb
@@ -17,7 +17,7 @@ module Airborne
             verify_ssl: verify_ssl
           ) { |response, request, result| response }
         rescue RestClient::Exception => e
-          e.response
+          e.response ? e.response : e.original_exception
         end
       else
         begin
@@ -28,7 +28,7 @@ module Airborne
             verify_ssl: verify_ssl
           ) { |response, request, result| response }
         rescue RestClient::Exception => e
-          e.response
+          e.response ? e.response : e.original_exception
         end
       end
       res


### PR DESCRIPTION
Currently, all exceptions are swallowed. In the case of `Timeout` exception, only `nil` response is returned. From the outside world, we have no info about `Timeout` exception.

This PR returns `exception.original_exception` if `exception.response` is not present. So from outside, we can know what is causing `response` to be `nil`.